### PR TITLE
Adds Mistral guidance to student pages

### DIFF
--- a/students/model-access.md
+++ b/students/model-access.md
@@ -33,6 +33,7 @@ After working through this page, students should be better able to:
 - use Claude Code with `Claude Pro` or `Claude Max` when you want one clear
   paid coding-tool path
 - use direct APIs when you want provider choice, scripting, or automation
+- use Mistral when you want an EU-based hosted alternative with a student plan
 - use OpenCode Zen when you want a curated set of models inside OpenCode
 - use Ollama when you want local or offline models and have enough hardware
 
@@ -83,6 +84,7 @@ Common examples are:
 
 - OpenAI API
 - Anthropic API for Claude models
+- Mistral API
 
 With direct APIs, you normally:
 
@@ -99,6 +101,13 @@ In OpenCode, this usually means using `/connect` and then `/models`.
 Important: subscriptions and APIs are different. Paying for a chat app or a
 coding subscription does not automatically mean you have a separate
 general-purpose API key.
+
+If you want an EU-based hosted alternative, Mistral is worth knowing. For
+student-facing planning, the main tiers to remember are `Free`, `Education`,
+and `Pro`. `Education` is the student-discounted plan, whilst `Pro` is the
+paid personal tier with more headroom. For stronger coding through the API,
+the practical Mistral pair to remember is `Mistral Small 4` for cheaper work
+and `Mistral Medium 3.5` for stronger work.
 
 ## OpenCode Zen
 
@@ -194,6 +203,9 @@ committing.
 | Claude Pro | $20/mo monthly or $17/mo annual | More usage; includes Claude Code and Claude Cowork | Claude Code Pro is not a separate SKU on the pricing page | [Claude Pro pricing](https://claude.com/pricing/pro) | Mixed but still strong. Earlier off-peak promos were popular, and [Daniel](https://www.kth.se/profile/dbosk) and Ric both get good work out of Claude, but there is recurring session-limit anxiety and active planning around resets. Productive, but not very predictable. |
 | Claude Max 5x | $100/mo | 5x more usage than Pro | Includes Claude Code | [Claude Max pricing](https://claude.com/pricing/max) | Likely better if you value continuity more than price, but the course discussion did not include concrete hands-on Max feedback. The appeal is mainly buying relief from limits. |
 | Claude Max 20x | $200/mo | 20x more usage than Pro | Includes Claude Code | [Claude Max pricing](https://claude.com/pricing/max) | Same caveat as Max 5x. Probably attractive only for very heavy use. Claude is admired for output quality, but the pricing and limit model still seems to create more mental overhead than the alternatives. |
+| Mistral Free | $0 | Limited Vibe access: limited messages, web searches, and coding sessions; API pricing is separate PAYG | Good for trying Mistral quickly without upfront cost | [Mistral pricing](https://mistral.ai/pricing), [Vibe overview](https://mistral.ai/products/le-chat) | Initially looked generous enough to try, but Daniel reported exhausting the free allowance quickly and not liking the quality enough to justify depending on it. |
+| Mistral Education | $5.99 | Verified-student plan; max 12 months; only for students who have not used Vibe or Le Chat before | Most student-relevant Mistral paid tier if you are eligible | [Mistral pricing](https://mistral.ai/pricing) | Sensible if you specifically want to try Mistral as an EU-based option, but not discussed as a clear Claude replacement for hard coding work. |
+| Mistral Pro | $14.99/mo | Up to 6x Free messages, up to 5x web searches, up to 40x image generation; positioned as all-day coding; beyond plan limits, usage continues at API rate | Best understood as the paid personal Mistral tier | [Mistral pricing](https://mistral.ai/pricing) | More explicit than some fuzzy plans, but the in-thread feeling was still that the quality/headroom tradeoff looked clearly worse than Anthropic for Daniel's use case. |
 | GitHub Copilot Pro+ | $39/mo | 1,500 premium requests/mo; unlimited agent mode and chats with GPT-5 mini; unlimited inline suggestions | Extra premium requests at $0.04/request; usage-based billing changes are coming June 1 | [Copilot plans](https://github.com/features/copilot/plans), [Copilot billing docs](https://docs.github.com/en/copilot/concepts/billing/copilot-requests) | Sentiment turned negative after the billing change announcement. Daniel and Ric both reacted as if the old deal had been unusually generous and was now getting worse. Predictability seems worse after the multiplier and usage-based billing news. |
 | OpenCode Go | $5 first month, then $10/mo | Hard limits: $12 per 5 hours, $30/week, $60/month | Beta | [OpenCode Go docs](https://opencode.ai/docs/go/) | Positive on workflow. Daniel explicitly praised OpenCode for dynamic context pruning and uses it strategically when Claude is near its limit. The usage model is understandable and the product helps extend productive time rather than creating more anxiety. |
 | OpenCode Zen | pay-as-you-go | No fixed monthly cap; per-request billing, free models available, spend limits configurable | More prepaid or PAYG than a normal monthly subscription | [OpenCode Zen docs](https://opencode.ai/docs/zen/) | Probably the most predictable in accounting terms because it is explicit PAYG, but that also means less of the cosy all-you-can-eat feeling. Respectable and transparent, though not discussed emotionally in the same way as Claude or Codex. |
@@ -205,6 +217,11 @@ A few naming caveats:
 
 - Claude Code Pro and Claude Code Max are really Claude Pro and Claude Max
   plans that include Claude Code.
+- Mistral's chat assistant is now called Vibe (formerly Le Chat), but the API
+  model layer is still separate.
+- For student work, the main Mistral API pair to remember is `Mistral Small 4`
+  for cheaper work and `Mistral Medium 3.5` for stronger coding work.
+- `Devstral 2` is deprecated, so do not learn it as a current default.
 - OpenAI Codex is currently bundled into ChatGPT plans rather than sold as
   its own consumer subscription.
 - OpenCode Zen is pay-as-you-go rather than a normal monthly plan.
@@ -221,6 +238,9 @@ From the course discussion:
 - **Best predictability and transparency:** OpenCode Zen, then OpenCode Go.
   Zen is explicit PAYG, and Go has visible hard caps. They may feel less
   luxurious than "unlimited-ish" plans, but they are easier to reason about.
+- **Best EU-based hosted alternative:** Mistral. Useful to know about if you
+  want an EU-based provider plus a student discount, but the course discussion
+  still treated it as a weaker coding option than Claude.
 - **Best workflow complement:** OpenCode as a harness. Independent of
   provider, Daniel explicitly likes OpenCode for dynamic context pruning and
   for extending productive time when Claude is near its limit.

--- a/students/which-model.md
+++ b/students/which-model.md
@@ -28,6 +28,10 @@ After working through this page, students should be better able to:
 
 - use Claude Opus when the task is hard, ambiguous, or needs deep reasoning
 - use Claude Sonnet or GPT-5.4 for everyday serious coding work
+- use Mistral Medium 3.5 when you want a current Mistral API model for stronger
+  coding work
+- use Mistral Small 4 when you want cheaper hosted API work and can accept a
+  lower ceiling
 - use GPT-5 mini for cheap helpers, subagents, and narrow mechanical tasks
 - use a larger Qwen model via Ollama if you want a local or self-hosted route
 - use a small Ollama model for quick utility help when frontier models are
@@ -43,6 +47,8 @@ than benchmark bragging.
 | Claude Opus | hardest debugging, architecture, forensics, ambiguous root-cause work, long chains of reasoning | usually the strongest overall reasoning and writing in this set | slower, more expensive, more session-limit anxiety |
 | Claude Sonnet | everyday serious coding, implementation, reviews, normal debugging | close to Opus on many tasks, but less reliable on the nastiest multi-step cases | cheaper and faster, but gives up some depth |
 | GPT-5.4 | strong general coding agent, implementation, edits across a repo, good default when you want throughput plus solid quality | roughly in the top working tier; usually not as prose-heavy as Opus, but very capable | quality can depend more on harness and provider policy |
+| Mistral Medium 3.5 | direct API coding work when you want a current Mistral flagship or an EU-based hosted alternative | strong enough for real work, but usually a step below Opus, Sonnet, or GPT-5.4 on the hardest tasks | weaker ceiling than the top frontier tools; best when provider choice or geography matters |
+| Mistral Small 4 | cheaper hosted API work, scripts, budget-conscious helpers, lighter coding tasks | useful budget model, but clearly below the stronger frontier coding models | lower cost and lower quality go together; use it when price matters more than maximum reliability |
 | GPT-5 mini | cheap and faster helper for boilerplate, small transforms, grep-and-fix style tasks, subagents | clearly below the big frontier models, but often good enough for scoped tasks | weaker judgement, easier to drift on larger changes |
 | Qwen larger open models | local or self-hosted coding help, decent code generation, useful when privacy, control, or cost matter | surprisingly strong for open weights, but usually below top proprietary models on hard reasoning | more setup, more variance by size and quantisation, weaker long-horizon reliability |
 | Kimi or Kimi K2 style models | long-context reading, broad synthesis, sometimes very good value | can be excellent for some analysis and synthesis workloads | availability and deployment path is less universal; coding reliability still depends on task and harness |
@@ -55,6 +61,8 @@ A short practical ranking by task:
 
 - hardest reasoning, debugging, or architecture: Claude Opus
 - best balance for normal serious work: Claude Sonnet or GPT-5.4
+- best Mistral choice for stronger hosted coding: Mistral Medium 3.5
+- best cheaper hosted API option in the Mistral family: Mistral Small 4
 - best cheap helper, subagent, or mechanical worker: GPT-5 mini
 - best if you want local or open-weight control: larger Qwen-class models via
   Ollama
@@ -65,10 +73,12 @@ A simple decision rule:
 
 1. If the task is scary or ambiguous, start with Opus.
 2. If the task is real but not pathological, use Sonnet or GPT-5.4.
-3. If the task is narrow and repetitive, use GPT-5 mini.
-4. If the task must stay local or self-hosted, use Qwen or another larger
+3. If you want a current Mistral route, use Medium 3.5 for stronger work or
+   Small 4 for cheaper work.
+4. If the task is narrow and repetitive, use GPT-5 mini.
+5. If the task must stay local or self-hosted, use Qwen or another larger
    open model via Ollama.
-5. If the task is for students, toy help, or no-budget inference, use smaller
+6. If the task is for students, toy help, or no-budget inference, use smaller
    Ollama models.
 
 ## Expected quality ladder
@@ -77,7 +87,7 @@ Very roughly, from strongest to weakest on hard work:
 
 1. Claude Opus
 2. Claude Sonnet ~= GPT-5.4
-3. strong open-weight models / Kimi-tier (depending on task)
+3. Mistral Medium 3.5 / strong open-weight models / Kimi-tier (depending on task)
 4. mini models
 5. small local Ollama models
 
@@ -104,8 +114,10 @@ A practical pattern several practitioners in this course use is:
 
 1. plan a hard change with Opus inside Claude Code
 2. switch to GPT-5.4 inside OpenCode to actually implement the plan
-3. delegate small mechanical edits or searches to GPT-5 mini as subagents
-4. fall back to a local model for offline work or when subscription limits
+3. use Mistral Small 4 or Medium 3.5 for direct API experiments when you want
+   a hosted alternative outside the OpenAI or Anthropic stack
+4. delegate small mechanical edits or searches to GPT-5 mini as subagents
+5. fall back to a local model for offline work or when subscription limits
    are hit
 
 This is not the only pattern, but it illustrates that model choice is rarely
@@ -120,23 +132,27 @@ Try these short scenarios before looking at the suggested answers:
    problem. Which model family should you try first?
 2. You want a good everyday default for serious coding work without always
    paying for the strongest model. Which model family fits best?
-3. You need a cheap helper for narrow, repetitive edits or subagent work. Which
+3. You want a budget hosted API model and can accept a lower ceiling than the
+   top frontier tools. Which model family fits best?
+4. You need a cheap helper for narrow, repetitive edits or subagent work. Which
    model family fits best?
-4. Privacy or local control matters more than frontier quality. Which model
+5. Privacy or local control matters more than frontier quality. Which model
    family fits best?
 
 Suggested answers:
 
 1. Claude Opus.
 2. Claude Sonnet or GPT-5.4.
-3. GPT-5 mini.
-4. A larger open model through Ollama, such as Qwen.
+3. Mistral Small 4.
+4. GPT-5 mini.
+5. A larger open model through Ollama, such as Qwen.
 
 ## Short version
 
 1. Match the model to the task, not to the hype.
-2. Use Opus for hard work, Sonnet or GPT-5.4 for everyday work, mini models
-   for cheap helpers, and Ollama models for local use.
+2. Use Opus for hard work, Sonnet or GPT-5.4 for everyday work, Mistral
+   Medium 3.5 or Small 4 for hosted API alternatives, mini models for cheap
+   helpers, and Ollama models for local use.
 3. Remember that the harness around the model matters at least as much as
    the model itself.
 4. Mix models across a workflow when it makes sense.


### PR DESCRIPTION
## Summary
- add Mistral subscription guidance to the student model-access page
- add Mistral model recommendations to the student which-model page
- position Mistral as an EU-based hosted alternative while noting current trade-offs

## Testing
- not run (documentation-only changes)